### PR TITLE
Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ p9k-theme-pastel is a theme for the [powerlevel10k](https://github.com/romkatv/p
 
 ### Zinit (Formerly Zplugin)
 
-Add `zinit light iboyperson/p9k-theme-pastel` to `~/.zshrc`.
+If you haven't already, install [powerlevel10k](https://github.com/romkatv/powerlevel10k#zinit).
+Then, add `zinit light iboyperson/p9k-theme-pastel` to `~/.zshrc`.
 
 ## Usage outside of a desktop
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ p9k-theme-pastel is a theme for the [powerlevel10k](https://github.com/romkatv/p
 
 ### Zinit (Formerly Zplugin)
 
-Installation: `zinit light-mode for $HOME/projects/p9k-theme-pastel`
+Add `zinit light iboyperson/p9k-theme-pastel` to `~/.zshrc`.
 
 ## Usage outside of a desktop
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ p9k-theme-pastel is a theme for the [powerlevel10k](https://github.com/romkatv/p
 
 ## Installation / Usage
 
+This project requires [Powerlevel10k](https://github.com/romkatv/powerlevel10k#get-started).
+Install that first, then follow the instructions below for your plugin manager of choice.
+
 ### Zinit (Formerly Zplugin)
 
-If you haven't already, install [powerlevel10k](https://github.com/romkatv/powerlevel10k#zinit).
-Then, add `zinit light iboyperson/p9k-theme-pastel` to `~/.zshrc`.
+Add `zinit light iboyperson/p9k-theme-pastel` to `~/.zshrc`.
 
 ## Usage outside of a desktop
 


### PR DESCRIPTION
While I was installing ZSH after coming back to Arch, I noticed that your installation instructions used a local copy of the repo at `~/projects/p9k-theme-pastel` rather than GitHub. I also completely forgot that dependencies weren't automatically resolved, so it took me a bit to remember to install p10k first. I figured that including those changes could save people some confusion, hence this pr.

Additionally, as far as I can tell, the originally used `zinit light-mode for` is only useful when loading multiple packages from a single command, which is why I changed it here to `zinit light`. I'm certainly not an expert so that might not be correct.